### PR TITLE
refactor(api): remove token expiration

### DIFF
--- a/apps/api/app/Controllers/Http/AuthController.ts
+++ b/apps/api/app/Controllers/Http/AuthController.ts
@@ -26,9 +26,7 @@ export default class AuthController {
     }
 
     try {
-      const response = await auth.use('api').attempt(email, password, {
-        expiresIn: '1 hour',
-      })
+      const response = await auth.use('api').attempt(email, password)
       await limiter.delete(throttleKey)
       return response
     } catch {


### PR DESCRIPTION
Since this is an opaque token no need to set an expiration time. Each login creates a new token.